### PR TITLE
Fixed to work with latest pybitcointools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 btc
 ===
+
+(possibly incomplete) list of requirements which can be installed via pip install:
+
+* pillow
+* qrcode
+* scrypt
+* base58
+
+Also depends on pybitcointools from github.com:vbuterin/pybitcointools.git
+
+See coldwallet.py for usage

--- a/bip38.py
+++ b/bip38.py
@@ -3,7 +3,12 @@
 from Crypto.Cipher import AES
 import scrypt
 import hashlib
-from pybitcointools import *
+
+try:
+    from pybitcointools import *
+except ImportError:
+    from bitcoin import *
+
 import binascii
 import base58
 

--- a/coldwallet.py
+++ b/coldwallet.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
 
 import sys
-from pybitcointools.main import *
+
+# pybitcointools from (e.g.) github.com:vbuterin/pybitcointools.git
+try:
+    from pybitcointools.main import *
+except ImportError:
+    from bitcoin.main import *
+
 from PIL import Image, ImageFont, ImageOps, ImageChops, ImageDraw
 import qrcode
 from bip38 import *
@@ -117,4 +123,5 @@ Usage:
       Generates an 8.5x11 @ 300dpi image with 8 BIP38 cold wallets
 
     If filename is not provided, output will be to wallet.png by default
+
 """


### PR DESCRIPTION
It looks like pybitcointools renamed the library to "bitcoin", so I updated the imports. I left the old import to be backwards compatible if you have an old version of the library installed.

I also added a tiny bit of info to the readme.

Thanks for the work on this! This is exactly the tool I've been looking for for cold wallet generation
